### PR TITLE
feat: add monitoring example with netdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_STORE
+
 #
 # Exclude common files and directories for examples/applications running in a subfolder of this nginx-proxy:
 #

--- a/examples/monitoring/.env.example
+++ b/examples/monitoring/.env.example
@@ -1,0 +1,13 @@
+# Domain that the application should be deployed to
+# TODO: CHANGE ME:
+DOMAIN=monitoring.example.de
+
+# FQDN (full qualified domain name) of the DOMAIN above
+# It is e.g. displayed in the browser tab and application menu
+# TODO: CHANGE ME:
+HOST_FQDN=example.de
+
+# check virtualization on your host system with "systemd-detect-virt -v"
+# leave empty if you have no virtualization
+# TODO: CHANGE ME:
+VIRTUALIZATION=

--- a/examples/monitoring/docker-compose.yml
+++ b/examples/monitoring/docker-compose.yml
@@ -1,0 +1,58 @@
+# This docker-compose deploys a netdata server monitoring service.
+# It shows e.g. real time metrics for you server's CPU, RAM, network, disk usage etc.
+# Also shows metrics for all docker containers individually.
+#
+# TODO: CHANGE ME:
+# Its recommended to secure this application with basic authentication (username + password)
+# so that no one gets unauthorized insights of your server. When using this nginx-proxy, follow the instructions on:
+# https://github.com/larsrickert/nginx-proxy/blob/main/docker-compose.yml
+version: '3'
+
+services:
+  netdata:
+    image: netdata/netdata:stable
+    hostname: '${HOST_FQDN}'
+    restart: always
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor:unconfined
+    volumes:
+      - netdataconfig:/etc/netdata
+      - netdatalib:/var/lib/netdata
+      - netdatacache:/var/cache/netdata
+      # /etc/passwd and /etc/group are used to get proper user and group names for the monitored host.
+      # They can be removed to get slightly better security
+      # - /etc/passwd:/host/etc/passwd:ro
+      # - /etc/group:/host/etc/group:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /etc/os-release:/host/etc/os-release:ro
+    environment:
+      VIRTUALIZATION: '${VIRTUALIZATION}'
+      DISABLE_TELEMETRY: 1
+      DOCKER_HOST: proxy:2375
+      VIRTUAL_HOST: '${DOMAIN}'
+      LETSENCRYPT_HOST: '${DOMAIN}'
+    networks:
+      - default
+      - nginx-proxy
+
+  # proxy for host docker socket (more secure than mounting directly to netdata service)
+  proxy:
+    image: tecnativa/docker-socket-proxy
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      CONTAINERS: 1
+
+volumes:
+  netdataconfig:
+  netdatalib:
+  netdatacache:
+
+networks:
+  default:
+  nginx-proxy:
+    external: true

--- a/examples/static-site/docker-compose.yml
+++ b/examples/static-site/docker-compose.yml
@@ -1,4 +1,4 @@
-# This docker-compose deploys a static site (such as angular/vue/react app or just playn html file).
+# This docker-compose deploys a static site (such as angular/vue/react app or just plain html/css/js files).
 # Unknown url routes are redirect to the index.html which is the expected behaviour for
 # SPAs = single page applications such as a vue app.
 version: '3'


### PR DESCRIPTION
The netdata monitoring example shows e.g. real time metrics for you server's CPU, RAM, network, disk usage etc.
It also shows metrics for all docker containers individually.