### PR TITLE
chore: bump minimum node version

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "packageManager": "pnpm@9.0.6",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
-    "commander": "^11.1.0",
+    "commander": "^12.0.0",
     "shelljs": "~0.8.5"
   },
   "devDependencies": {

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       commander:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^12.0.0
+        version: 12.0.0
       shelljs:
         specifier: ~0.8.5
         version: 0.8.5
@@ -340,9 +340,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  commander@11.1.0:
-    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
-    engines: {node: '>=16'}
+  commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -2066,7 +2066,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  commander@11.1.0: {}
+  commander@12.0.0: {}
 
   compare-func@2.0.0:
     dependencies:

--- a/docs/cli/github-actions.md
+++ b/docs/cli/github-actions.md
@@ -22,6 +22,11 @@ In order to login to your linux server, you need to add your user credentials as
 
 Inside your git repository, create a `.github/workflows/deploy.yml` file and add the following content:
 
+:::tip CLI version
+We recommend to specify the major version of the CLI to use (e.g. `npx nginx-proxy-cli@3`).
+Otherwise, breaking changes we make to the CLI might break your existing GitHub actions.
+:::
+
 ```yaml
 name: Deploy
 on:
@@ -35,15 +40,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Deploy
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1.0.3
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           password: ${{ secrets.SSH_PASSWORD }}
           envs: GITHUB_SERVER_URL,GITHUB_REPOSITORY
-          script: npx nginx-proxy-cli deploy $GITHUB_SERVER_URL/$GITHUB_REPOSITORY --dir=~/nginx-proxy/applications
+          script: npx nginx-proxy-cli@3 deploy $GITHUB_SERVER_URL/$GITHUB_REPOSITORY --dir=~/nginx-proxy/applications
 ```
 
 **Notes**:

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -4,29 +4,22 @@ The `nginx-proxy` offers a Node CLI that can be used to e.g. simplify or automat
 
 ## Prerequisites
 
-You need to have node installed on your system when you want to use the CLI.
+You need to have [Node.js](https://nodejs.org) `>= 18` installed on your system when you want to use the CLI.
 
 ### Install node
 
-- **Step 1:** Get installation script with (replacing `16.x` with the version that you want to install):
+We recommend to install node using [fnm](https://github.com/Schniz/fnm).
+
+- **Step 1:** Follow the [fnm installation instructions](https://github.com/Schniz/fnm?tab=readme-ov-file#installation)
+
+- **Step 2:** Install your desired node version
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh
+fnm install 20
+fnm default 20
 ```
 
-- **Step 2:** Execute the script with:
-
-```bash
-bash nodesource_setup.sh
-```
-
-- **Step 3:** Install node
-
-```bash
-apt install nodejs
-```
-
-- **Step 4 (optional):** Check node version
+- **Step 3 (optional):** Verify installation
 
 ```bash
 node -v


### PR DESCRIPTION
Node 16 has reached end of life a while ago so we update to `>= 18`

BREAKING CHANGE: bump min node version to `>= 18`